### PR TITLE
Typo  RAK7258 / Quickstart.

### DIFF
--- a/docs/Product-Categories/WisGate/RAK7258/Quickstart/README.md
+++ b/docs/Product-Categories/WisGate/RAK7258/Quickstart/README.md
@@ -117,7 +117,7 @@ In this section, several ways in accessing the gateway are provided to have diff
 
 #### Wi-Fi AP Mode
 
-By default, the Gateway will work in Wi-Fi AP Mode which means that you can find an SSID named like "**RAK7258_XXXX**" on your PC's Wi-Fi Network List. "**XXXX**" is is the last two bytes of the Gateway MAC address.
+By default, the Gateway will work in Wi-Fi AP Mode which means that you can find an SSID named like "**RAK7258_XXXX**" on your PC's Wi-Fi Network List. "**XXXX**" is the last two bytes of the Gateway MAC address.
 
 :::tip 📝 NOTE:
  No password is required to connect via Wi-Fi


### PR DESCRIPTION
Small typo on  RAK7258 > Quickstart.